### PR TITLE
Update paper when major build changes

### DIFF
--- a/roles/minecraft/tasks/updates/papermc.yml
+++ b/roles/minecraft/tasks/updates/papermc.yml
@@ -24,7 +24,7 @@
     
     - ansible.builtin.include_tasks: updates/actions/delete.yml
   
-  when: (build_id | string) != file_build # We don't have latest version
+  when: ((build_id | string) != file_build) or (target_mc_version != file_version) # We don't have latest version
   vars:
     build: "{{ builds_default | last }}"
     build_id: "{{ build.build }}"


### PR DESCRIPTION
Instead of only checking if the build has changed, also check if the `target_mc_version` has changed.

Only applicable to paper, as only paper uses `target_mc_version`.