### PR TITLE
Use `target_mc_version` for papermc

### DIFF
--- a/roles/minecraft/tasks/updates/papermc.yml
+++ b/roles/minecraft/tasks/updates/papermc.yml
@@ -16,7 +16,7 @@
     - name: Download latest version
       ansible.builtin.get_url:
         url: "https://api.papermc.io/v2/projects/{{ file_project }}/versions/{{ target_mc_version }}/builds/{{ build.build }}/downloads/{{ build.download }}"
-        dest: "{{ new_file }}"
+        dest: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + target_mc_version + '_' + (build_id | string) + '.jar'] | path_join }}"
         headers:
           accept: application/java-archive
         force: true


### PR DESCRIPTION
Use `target_mc_version` instead of `file_version`.
This caused problems when updating between minecraft versions