### PR TITLE
Use rsync for combining files

### DIFF
--- a/roles/minecraft/tasks/push/combine.yml
+++ b/roles/minecraft/tasks/push/combine.yml
@@ -5,49 +5,18 @@
     when: not sources.0 is directory
     ignore_errors: true
   
-  - name: Combine templates and overrides, then push
+  - name: Combine templates and overrides
     block:
-      - name: Find directories
-        ansible.builtin.shell:
-          chdir: "{{ item }}"
-          cmd: "find * -type d" # We have to use `cd` to not show the path, only file name
-        loop: "{{ sources }}"
-        register: dirs
-        changed_when: false
-        failed_when:
-          - dirs.rc != 0
-          - (not dirs.stderr is search('No such file or directory', ignorecase=true)) or (dirs.stderr_lines | length) > 1
-      
-      - name: Find files
-        ansible.builtin.shell:
-          chdir: "{{ item }}"
-          cmd: find * -type f
-        loop: "{{ sources }}"
-        register: files_out
-        changed_when: false
-        failed_when:
-          - files_out.rc != 0
-          - (not files_out.stderr is search('No such file or directory', ignorecase=true)) or (files_out.stderr_lines | length) > 1
-      
-      - name: Create tmp directories
+      - name: Create tmp directory
         ansible.builtin.file:
           state: directory
-          path: "{{ [tmp_path, item] | path_join }}"
-        loop: "{{ (dir_list | length != 0) | ternary(dir_list, ['']) }}"
-        vars:
-          dir_list: "{{ dirs.results | map(attribute='stdout_lines') | flatten | unique }}"
+          path: "{{ tmp_path }}"
         changed_when: false
       
-      - name: Populate tmp directory
-        ansible.builtin.file:
-          state: link
-          src: "{{ (item.0.key, item.1) | path_join }}"
-          dest: "{{ (tmp_path, item.1) | path_join }}"
-        loop: "{{ sources | zip([files.0 | difference(files.1), files.1]) | community.general.dict | dict2items | subelements('value') }}"
-        loop_control:
-          label: "{{ item.1 }}"
-        vars:
-          files: "{{ files_out.results | map(attribute='stdout_lines') }}"
+      # We can't use ansible.posix.rsync because it does not support rsync on the same host
+      - name: Copy template and overrides
+        ansible.builtin.command: /usr/bin/rsync --delay-updates -F --compress --checksum --recursive --perms -S --exclude=.* --out-format='CHANGED >> %i %n%L' {{ item }}/ {{ tmp_path }}/
+        loop: "{{ sources }}"
         changed_when: false
       
       - ansible.builtin.set_fact:

--- a/roles/minecraft/tasks/push/synchronize.yml
+++ b/roles/minecraft/tasks/push/synchronize.yml
@@ -13,7 +13,7 @@
   become: true
   become_user: "{{ user }}"
   vars:
-    rsync_path: "{{ [tmp_dict[dir_name], '.'] | path_join }}"
+    rsync_path: "{{ tmp_dict[dir_name] }}/"
 
 - name: Delete files
   ansible.builtin.file:


### PR DESCRIPTION
Use `ansible.posix.rsync` for combining files in `push` operations.

This drastically improves performace and allows the combination of a large number of files.

Fixes #12