### PR TITLE
Geysermc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,6 @@ File name format for different update sources:
 - Jenkins: `AUTOUPDATE_COMMENT_jenkins_jenkinsUrl_fileNameToDownloadPrefix_0.jar`
 - Modrinth: `AUTOUPDATE_COMMENT_modrinth_pluginName_releasePlatform_0.jar`
 - PaperMC: `AUTOUPDATE_COMMENT_papermc_project_mcVersion_0.jar` (For Paper, the target mcVersion must also be set in `target.mcversion` file)
+- GeyserMC: `AUTOUPDATE_COMMENT_geysermc_project-platform_0_0.jar`
 - ProjectKorra: `AUTOUPDATE_COMMENT_projectkorra_id__0.jar`
 - SpigotMC: `AUTOUPDATE_COMMENT_spigotmc_id__0.jar`

--- a/roles/minecraft/tasks/updates/geysermc.yml
+++ b/roles/minecraft/tasks/updates/geysermc.yml
@@ -17,8 +17,8 @@
   block:
     - name: Download latest version
       ansible.builtin.get_url:
-        url: "https://download.geysermc.org/v2/projects/{{ file_project | split('-') | first }}/builds/{{ build_id }}/downloads/{{ file_project | split('-') | last }}"
-        dest: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + target_mc_version + '_' + (build_id | string) + '.jar'] | path_join }}"
+        url: "https://download.geysermc.org/v2/projects/{{ file_project | split('-') | first }}/versions/{{ versions.json.versions | last }}/builds/{{ build_id }}/downloads/{{ file_project | split('-') | last }}"
+        dest: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + (versions.json.versions | last) + '_' + (build_id | string) + '.jar'] | path_join }}"
         headers:
           accept: application/java-archive
         force: true

--- a/roles/minecraft/tasks/updates/geysermc.yml
+++ b/roles/minecraft/tasks/updates/geysermc.yml
@@ -1,0 +1,30 @@
+# Example: AUTOUPDATE_COMMENT_geysermc_geyser-spigot_2.2.0_410.jar
+- name: Get available versions
+  ansible.builtin.uri:
+    url: "https://download.geysermc.org/v2/projects/{{ file_project | split('-') | first }}"
+    headers:
+      accept: application/json
+  register: versions
+
+- name: Get available builds
+  ansible.builtin.uri:
+    url: "https://download.geysermc.org/v2/projects/{{ file_project | split('-') | first }}/versions/{{ versions.json.versions | last }}"
+    headers:
+      accept: application/json
+  register: builds
+
+- name: Update to latest version
+  block:
+    - name: Download latest version
+      ansible.builtin.get_url:
+        url: "https://download.geysermc.org/v2/projects/{{ file_project | split('-') | first }}/builds/{{ build_id }}/downloads/{{ file_project | split('-') | last }}"
+        dest: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + target_mc_version + '_' + (build_id | string) + '.jar'] | path_join }}"
+        headers:
+          accept: application/java-archive
+        force: true
+    
+    - ansible.builtin.include_tasks: updates/actions/delete.yml
+  
+  when: ((build_id | string) != file_build) or ((versions.json.versions | last) != file_version) # We don't have latest version
+  vars:
+    build_id: "{{ builds.json.builds | last }}"


### PR DESCRIPTION
Geysermc recently changed from jenkins to a custom [downloads api](https://download.geysermc.org/docs/).

- [x] Add support for the new API
- [x] Update README with new info