### PR TITLE
Support for modrinth projects with multiple versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ File name format for different update sources:
 - GitHub: `AUTOUPDATE_COMMENT_github_Author:Repo_fileNameToDownloadPrefix_0.jar`
 - Hangar: `AUTOUPDATE_COMMENT_hangar_Author:Name_releasePlatform_0.jar`
 - Jenkins: `AUTOUPDATE_COMMENT_jenkins_jenkinsUrl_fileNameToDownloadPrefix_0.jar`
-- Modrinth: `AUTOUPDATE_COMMENT_modrinth_pluginName_releasePlatform_0.jar`
-- PaperMC: `AUTOUPDATE_COMMENT_papermc_project_mcVersion_0.jar` (For Paper, the target mcVersion must also be set in `target.mcversion` file)
+- Modrinth: `AUTOUPDATE_COMMENT_modrinth_pluginName_releasePlatform_0.jar` (for modrinth, the server version is taken from `target.mcversion` file. The updater will only download versions caompatible with the server, you can skip this check using a `!` before the `releasePlatform`. This is needed for velocity plugins)
+- PaperMC: `AUTOUPDATE_COMMENT_papermc_project_mcVersion_0.jar` (for paper, the target mcVersion must also be set in `target.mcversion` file)
 - GeyserMC: `AUTOUPDATE_COMMENT_geysermc_project-platform_0_0.jar`
 - ProjectKorra: `AUTOUPDATE_COMMENT_projectkorra_id__0.jar`
 - SpigotMC: `AUTOUPDATE_COMMENT_spigotmc_id__0.jar`

--- a/roles/minecraft/tasks/updates/modrinth.yml
+++ b/roles/minecraft/tasks/updates/modrinth.yml
@@ -1,17 +1,18 @@
 # AUTOUPDATE_COMMENT_modrinth_tab-was-taken_paper_123.jar
 - name: Get latest version
   ansible.builtin.uri:
-    url: "https://api.modrinth.com/v2/project/{{ file_project | replace('#', '_') | lower }}/version?loaders=[%22{{ file_version | lower }}%22]&game_versions=[%22{{ target_mc_version }}%22]"
+    url: "https://api.modrinth.com/v2/project/{{ file_project | replace('#', '_') | lower }}/version?loaders={{ (file_version is regex('^!')) | ternary('[%22' + (file_version[1:] | lower) + '%22]', '[%22' + (file_version | lower) + '%22]&game_versions=[%22' + target_mc_version + '%22]') }}"
     headers:
       accept: application/json
   register: versions
 
 - name: Check that versions are available
   ansible.builtin.fail:
-    msg: "There are no modrinth release versions for {{ file_project | replace('#', '_') | lower }}, that use the {{ file_version | lower }} loader, and is compatible with {{ target_mc_version }}"
+    msg: "There are no modrinth release versions for {{ file_project | replace('#', '_') | lower }}, that use the {{ file_version | lower }} loader, and are compatible with {{ target_mc_version }}"
   when: (versions.json | length) == 0 or (versions_release | length) == 0
 
 - name: Update to the latest version
+
   block:
     - name: Download latest release
       ansible.builtin.get_url:

--- a/roles/minecraft/tasks/updates/modrinth.yml
+++ b/roles/minecraft/tasks/updates/modrinth.yml
@@ -1,7 +1,7 @@
 # AUTOUPDATE_COMMENT_modrinth_tab-was-taken_paper_123.jar
 - name: Get latest version
   ansible.builtin.uri:
-    url: "https://api.modrinth.com/v2/project/{{ file_project | replace('#', '_') | lower }}/version?loaders=[%22{{ file_version | lower }}%22]"
+    url: "https://api.modrinth.com/v2/project/{{ file_project | replace('#', '_') | lower }}/version?loaders=[%22{{ file_version | lower }}%22]&game_versions=[%22{{ target_mc_version }}%22]"
     headers:
       accept: application/json
   register: versions

--- a/roles/minecraft/tasks/updates/modrinth.yml
+++ b/roles/minecraft/tasks/updates/modrinth.yml
@@ -8,7 +8,7 @@
 
 - name: Check that versions are available
   ansible.builtin.fail:
-    msg: "There are no modrinth release versions for {{ file_project | replace('#', '_') | lower }}, that use the {{ file_version | lower }} loader"
+    msg: "There are no modrinth release versions for {{ file_project | replace('#', '_') | lower }}, that use the {{ file_version | lower }} loader, and is compatible with {{ target_mc_version }}"
   when: (versions.json | length) == 0 or (versions_release | length) == 0
 
 - name: Update to the latest version
@@ -21,9 +21,9 @@
           accept: application/octet-stream
         force: true
         checksum: "sha512:{{ new_release.hash.0 }}"
-    
+
     - ansible.builtin.include_tasks: updates/actions/delete.yml
-  
+
   when: (build_id | string) != file_build
   vars:
     new_release: "{{ versions_release | first }}"

--- a/roles/minecraft/vars/main.yml
+++ b/roles/minecraft/vars/main.yml
@@ -10,7 +10,8 @@ tmp_path: "{{ [tmp_dir, dir_name] | path_join }}"
 
 # UPDATE
 file_dir: "{{ file | dirname }}"
-target_mc_version: "{{ lookup('ansible.builtin.file', [file_dir, mc_version_file] | path_join, lstrip='true') }}"
+file_root_dir: "{{ [template_dir, (file_dir | relpath(template_dir) | split('/') | first)] | path_join }}"
+target_mc_version: "{{ lookup('ansible.builtin.file', [file_root_dir, mc_version_file] | path_join, lstrip='true') }}"
 
 new_file: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + file_version + '_' + (build_id | string) + '.jar'] | path_join }}"
 


### PR DESCRIPTION
Downloads the latest modrinth release for the server version, instead of the first one.

- [x] Add support for `target_mc_version` in non root directories
- [x] Force modrinth update service to download only compatible versions