### PR TITLE
Fix modrinth update in overrides directory

### DIFF
--- a/roles/minecraft/vars/main.yml
+++ b/roles/minecraft/vars/main.yml
@@ -10,7 +10,8 @@ tmp_path: "{{ [tmp_dir, dir_name] | path_join }}"
 
 # UPDATE
 file_dir: "{{ file | dirname }}"
-file_root_dir: "{{ [template_dir, (file_dir | relpath(template_dir) | split('/') | first)] | path_join }}"
+file_root_dir: "{{ file_dir.startswith(template_dir) | ternary([template_dir, (file_dir | relpath(template_dir) | split('/') | first)] | path_join, [override_dir, (file_dir | relpath(override_dir) | split('/') | first)] | path_join) }}"
+
 target_mc_version: "{{ lookup('ansible.builtin.file', [file_root_dir, mc_version_file] | path_join, lstrip='true') }}"
 
 new_file: "{{ [file_dir, 'AUTOUPDATE_' + file_comment + '_' + file_service + '_' + file_project + '_' + file_version + '_' + (build_id | string) + '.jar'] | path_join }}"


### PR DESCRIPTION
When updating modrith files, the `target.mcversion` file is used to choose the correct version.

However, the lookup of the file failed as the path incorrectly resolved to the base directory instead of `overrides` when the autoupdate file was in the `overrides` directory.